### PR TITLE
Update to help documentation

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -1,3 +1,5 @@
 # Getting help
 
-If you need help, please contact us following [these instructions](https://docs.rc.fas.harvard.edu/kb/support/).
+For general assistance, write to [ithelp@harvard.edu](mailto:ithelp@harvard.edu?subject=FAS OnDemand support). Since this is a general help address, please mention FAS OnDemand in the subject, and include a link to the course for which you need help.
+
+If something in FAS OnDemand is broken in a way that prevents your class from working in the platform, please also write to [fasondemand@rc.fas.harvard.edu](mailto:fasondemand@rc.fas.harvard.edu) to alert the platform maintainers in FAS Research Computing.

--- a/docs/rstudio.md
+++ b/docs/rstudio.md
@@ -141,7 +141,7 @@ If Rstudio will not start and you get an error message like this:
 
 Wait 2-3 minutes and try to re-launch the application. This may happen the very first time you login to FAS OnDemand and your account hasn't been fully provisioned yet.
 
-If you continue to get this error or otherwise cannot start Rstudio, please contact ithelp@harvard.edu for assistance.
+If you continue to get this error or otherwise cannot start Rstudio, please contact [ithelp@harvard.edu](mailto:ithelp@harvard.edu) for assistance.
 
 ### Problem logging in to Rstudio
 

--- a/docs/tour.md
+++ b/docs/tour.md
@@ -4,7 +4,7 @@ When you first launch FAS OnDemand from your Canvas course, you will land on a d
 
 ![Dashboard screenshot](images/dashboard.png?raw=true)
 
-1. **Interactive Apps**: Lists the interactive applications that are setup for your class. To start an app, simply click on the icon and follow the prompts to start a new *interactive session*. Note that you can always access the list of apps from the top navigation bar as well.
+1. **Interactive Apps**: Lists the interactive applications that are set up for your class. To start an app, simply click on the icon and follow the prompts to start a new *interactive session*. Note that you can always access the list of apps from the top navigation bar as well.
 2. **Tools**: Additional tools that are specific to FAS OnDemand to help you manage files, jobs, etc. These are all optional tools. It's possible to do everything you need within the application itself.
     - **Home Directory**: Your home directory will be mounted automatically by the interactive apps, so any changes you make in the app will be available here, and vice versa. In some cases, it is more convenient to upload/download large files using this tool.
     - **Job Composer** (advanced): For submitting batch jobs. Most users will not need this.


### PR DESCRIPTION
Direct people to ithelp for most issues for triage, and to include fasondemand email if they encounter breaking issues. Also added a couple minor text changes.